### PR TITLE
feat: add polymer dependency for Vaadin 25 support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -387,7 +387,7 @@
 			<properties>
 				<maven.compiler.source>21</maven.compiler.source>
 				<maven.compiler.target>21</maven.compiler.target>
-				<vaadin.version>25.0.0-beta5</vaadin.version>
+				<vaadin.version>25.0.3</vaadin.version>
 				<jetty.version>11.0.26</jetty.version>
 				<flowingcode.commons.demo.version>5.2.0</flowingcode.commons.demo.version>
 			</properties>

--- a/pom.xml
+++ b/pom.xml
@@ -391,6 +391,13 @@
 				<jetty.version>11.0.26</jetty.version>
 				<flowingcode.commons.demo.version>5.2.0</flowingcode.commons.demo.version>
 			</properties>
+            <dependencies>
+                <dependency>
+                    <groupId>com.vaadin</groupId>
+                    <artifactId>vaadin-dev</artifactId>
+                    <optional>true</optional>
+                </dependency>
+            </dependencies>
 		</profile>
 		
     </profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -353,6 +353,7 @@
 										<exclude>**/integration/*</exclude>
 										<exclude>**/DemoView.class</exclude>
 										<exclude>**/DemoLayout.class</exclude>
+                                        <exclude>**/dynamic-theme.properties</exclude>
 									</excludes>
 								</configuration>
 							</execution>

--- a/src/main/java/com/flowingcode/vaadin/addons/granitealert/GraniteAlert.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/granitealert/GraniteAlert.java
@@ -2,7 +2,7 @@
  * #%L
  * Granite Alert
  * %%
- * Copyright (C) 2018 - 2020 Flowing Code
+ * Copyright (C) 2018 - 2026 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ import com.vaadin.flow.component.HasComponents;
 import com.vaadin.flow.component.HasStyle;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.dependency.JsModule;
+import com.vaadin.flow.component.dependency.NpmPackage;
 
 /**Wrapper for {@code granite-alert} Polymer element
  * 
@@ -36,6 +37,7 @@ import com.vaadin.flow.component.dependency.JsModule;
 @Tag("granite-alert-mixin")
 //@NpmPackage(value = "@granite-elements/granite-alert", version = "^2.1.2")
 //@JsModule("@granite-elements/granite-alert/granite-alert.js")
+@NpmPackage(value = "@polymer/polymer", version = "3.5.2")
 @JsModule("./granite-alert/granite-alert.js")
 @JsModule("./granite-alert-mixin/granite-alert-mixin.js")
 public class GraniteAlert extends Component implements HasComponents, HasStyle {

--- a/src/test/resources/META-INF/dynamic-theme.properties
+++ b/src/test/resources/META-INF/dynamic-theme.properties
@@ -1,0 +1,1 @@
+theme=LUMO


### PR DESCRIPTION
Close #18 

Tested for Vaadin 14, 24 & 25. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  - Upgraded Vaadin framework dependency to version 25.0.3
  - Integrated Polymer package (v3.5.2) for component support
  - Updated build and test artifact configurations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->